### PR TITLE
[feature] 해시태그 리스트 페이지(컴포넌트) 스켈레톤(HTML)을 작성합니다

### DIFF
--- a/frontend/code-flash-card/src/components/BackSpaceBtn.tsx
+++ b/frontend/code-flash-card/src/components/BackSpaceBtn.tsx
@@ -1,0 +1,6 @@
+export default function BackSpaceBtn() {
+  return (
+    <div>{'<-'}</div>
+    // TODO: <img/>  화살표 이미지
+  )
+}

--- a/frontend/code-flash-card/src/components/FlashCard.tsx
+++ b/frontend/code-flash-card/src/components/FlashCard.tsx
@@ -1,0 +1,11 @@
+import { Card } from "./FlashCards";
+
+export default function FlashCard({ card }: { card: Card }) {
+  const { explain, viewCount } = card;
+  return (
+    <li>
+      <p>{explain}</p>
+      <span>{viewCount}</span>
+    </li>
+  );
+}

--- a/frontend/code-flash-card/src/components/FlashCards.tsx
+++ b/frontend/code-flash-card/src/components/FlashCards.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import FlashCard from "./FlashCard";
+
+// TODO: UI View단을 위한 interface 보관 장소 만들기
+export interface Card {
+  cardId: number;
+  explain: string;
+  viewCount: number;
+}
+
+export default function FlashCards({ cards }: { cards: Card[] }) {
+  return (
+    <ul>
+      {
+        cards.map((card) => {
+          return (
+            <React.Fragment key={card.cardId}>
+              <FlashCard card={card} />
+            </React.Fragment>
+          )
+        })
+      }
+    </ul>
+  );
+}

--- a/frontend/code-flash-card/src/components/FlashCardsNav.tsx
+++ b/frontend/code-flash-card/src/components/FlashCardsNav.tsx
@@ -1,0 +1,7 @@
+import BackSpaceBut from "./BackSpaceBtn";
+
+export default function FlashCardsNav () {
+  return (
+    <BackSpaceBut />
+  )
+}

--- a/frontend/code-flash-card/src/components/FlashCardsTitle.tsx
+++ b/frontend/code-flash-card/src/components/FlashCardsTitle.tsx
@@ -1,0 +1,7 @@
+export default function FlashCardsTitle({ title }: { title: string; }) {
+  return (
+    <div>
+      <h1>{title}</h1>
+    </div>
+  )
+}

--- a/frontend/code-flash-card/src/pages/HashTagListPage.tsx
+++ b/frontend/code-flash-card/src/pages/HashTagListPage.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import FlashCards, { Card } from '../components/FlashCards'
+import FlashCardsNav from '../components/FlashCardsNav';
+import FlashCardsTitle from '../components/FlashCardsTitle'
+
+export default function HashTagListPage() {
+  const mockKeyword = '# 자바스크립트';
+  const mockCards: Card[] = [{
+    cardId : 1,
+    explain: "state",
+    viewCount: 100,
+  },{
+    cardId : 2,
+    explain: "useState",
+    viewCount: 200,
+  },{
+    cardId : 3,
+    explain: "useEffect",
+    viewCount: 300,
+  },{
+    cardId : 4,
+    explain: "reactQuery",
+    viewCount: 400,
+  },{
+    cardId : 5,
+    explain: "ESLint",
+    viewCount: 500,
+  },{
+    cardId : 6,
+    explain: "sprint",
+    viewCount: 600,
+  },
+];
+
+  return (
+    <>
+      <FlashCardsNav />
+      <FlashCardsTitle title={mockKeyword} />
+      <FlashCards cards={mockCards}/>
+    </>
+  )
+}


### PR DESCRIPTION
# 해시태그 리스트 페이지(컴포넌트) 스켈레톤(HTML) 작성을 작성합니다

## 내역
- [x] 폴더 구조 제작 (compoents / pages)
- [x] 리스트 페이지 컴포넌트 골격 제작
- [x] 해시태그 리스트 페이지 - Mock 데이터 제작
