### PR TITLE
[Add] 리포지토리에 Dependabot 기능을 활성화 합니다

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      # Check for npm updates on Sundays at 9am UTC
+      day: "sunday"
+      time: "09:00"
+    target-branch: "main"
+    allow:
+      - dependency-type: "production"
+    commit-message:
+      # Prefix all commit messages with "npm"
+      prefix: "npm"
+    assignees:
+      # You can change assignees, you can specify the assignees here
+    labels:
+      # You can change labels, you can specify the labels here
+      - "Dependencies"


### PR DESCRIPTION
# 리포지토리에 Dependabot 기능을 활성화 합니다
## 구현
- [x] Dependabot 기능 추가

## 이슈
- [x] 없음

## 참조
- 제가 CodeQL 기능과 Dependabot 기능을 헷갈렸습니다.
- CodeQL의 코드의 보안성을 검사합니다.
- Dependabot은 라이브러리의 버전을 정기적으로 관리해줍니다.
- @devseop 의 [PR](https://github.com/code-flash-card/code-flash-card/pull/47)에서 착안하여 패키지 버전을 자동으로 관리할 수 있도록 합니다.
- 참조부탁드립니다.